### PR TITLE
Remove support for Magento < 2.4.4 (and PHP < 7.4)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+## [2.0.2 (2026-02-18)]
+
+### Fixed
+- Add uat environments.
+
 ## [2.0.1] - 2026-02-17
 
 ### Updated

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,10 +6,12 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
-## [2.0.2 (2026-02-18)]
+## [2.0.2 (2026-02-20)]
 
 ### Fixed
 - Add uat environments.
+- Set expiration minutes in 30 minutes by default.
+
 
 ## [2.0.1] - 2026-02-17
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,10 +8,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [2.0.2 (2026-02-20)]
 
-### Fixed
+### Added
 - Add uat environments.
 - Set expiration minutes in 30 minutes by default.
-
 
 ## [2.0.1] - 2026-02-17
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,11 +6,15 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
-## [2.0.2 (2026-02-20)]
+## [2.1.0] - 2026-02-26
 
 ### Added
 - Add uat environments.
 - Set expiration minutes in 30 minutes by default.
+
+### Removed
+- Remove support for Magento < 2.4.4.
+- Remove support for PHP < 7.4.
 
 ## [2.0.1] - 2026-02-17
 

--- a/Helper/Data.php
+++ b/Helper/Data.php
@@ -335,6 +335,13 @@ class Data extends BaseData
                     $storeId
                 );
                 break;
+            case Mode::UAT:
+                $tranKey = $this->scopeConfig->getValue(
+                    'payment/placetopay/placetopay_uat_tk',
+                    ScopeInterface::SCOPE_STORE,
+                    $storeId
+                );
+                break;
             case Mode::CUSTOM:
                 $tranKey = $this->scopeConfig->getValue(
                     'payment/placetopay/placetopay_custom_tk',
@@ -369,6 +376,13 @@ class Data extends BaseData
             case Mode::TEST:
                 $login = $this->scopeConfig->getValue(
                     'payment/placetopay/placetopay_test_lg',
+                    ScopeInterface::SCOPE_STORE,
+                    $storeId
+                );
+                break;
+            case Mode::UAT:
+                $login = $this->scopeConfig->getValue(
+                    'payment/placetopay/placetopay_uat_lg',
                     ScopeInterface::SCOPE_STORE,
                     $storeId
                 );

--- a/Helper/Data.php
+++ b/Helper/Data.php
@@ -268,7 +268,7 @@ class Data extends BaseData
     /**
      * @return string|null
      */
-    public function getMode($storeId = null)
+    public function getMode(?string $storeId = null)
     {
         return $this->scopeConfig->getValue(
             'payment/placetopay/placetopay_mode',
@@ -280,7 +280,7 @@ class Data extends BaseData
     /**
      * @return string|null
      */
-    public function getCustomConnectionUrl($storeId = null): ?string
+    public function getCustomConnectionUrl(?string $storeId = null): ?string
     {
         return $this->scopeConfig->getValue(
             'payment/placetopay/placetopay_custom_url',
@@ -289,7 +289,7 @@ class Data extends BaseData
         );
     }
 
-    public function isCustomEnvironment($storeId = null): bool
+    public function isCustomEnvironment(?string $storeId = null): bool
     {
         return $this->getMode($storeId) === Mode::CUSTOM;
     }
@@ -297,7 +297,7 @@ class Data extends BaseData
     /**
      * @return string|null
      */
-    public function getUri($storeId = null): ?string
+    public function getUri(?string $storeId = null): ?string
     {
         $uri = null;
         $endpoints = $this->getEndpointsTo();
@@ -316,7 +316,7 @@ class Data extends BaseData
     /**
      * @return string|null
      */
-    public function getTranKey($storeId = null): ?string
+    public function getTranKey(?string $storeId = null): ?string
     {
         $mode = $this->getMode($storeId);
 
@@ -361,7 +361,7 @@ class Data extends BaseData
         return $tranKey;
     }
 
-    public function getLogin($storeId = null): ?string
+    public function getLogin(?string $storeId = null): ?string
     {
         $mode = $this->getMode($storeId);
 

--- a/Helper/Data.php
+++ b/Helper/Data.php
@@ -61,7 +61,7 @@ class Data extends BaseData
         );
         $this->infoFactory = $infoFactory;
         $this->logger = $logger;
-        $this->version = '2.0.1';
+        $this->version = '2.1.0';
 
         $this->mode = $this->getMode();
     }

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 # Usage:
-# make compile PLUGIN_VERSION=2.0.1
+# make compile PLUGIN_VERSION=2.1.0
 
 .PHONY: compile
 compile:

--- a/Model/Adminhtml/Source/Expiration.php
+++ b/Model/Adminhtml/Source/Expiration.php
@@ -7,7 +7,7 @@ use Magento\Store\Model\ScopeInterface;
 
 class Expiration
 {
-    private const EXPIRATION_TIME_MINUTES_DEFAULT = 8640;
+    private const EXPIRATION_TIME_MINUTES_DEFAULT = 2880;
     private const EXPIRATION_TIME_MINUTES_CL = 30;
 
     /**

--- a/Model/Adminhtml/Source/Mode.php
+++ b/Model/Adminhtml/Source/Mode.php
@@ -11,6 +11,7 @@ class Mode
     public const TEST = 'test';
     public const PRODUCTION = 'production';
     public const CUSTOM = 'custom';
+    public const UAT = 'uat';
     protected $dataHelper;
 
     public function __construct(Data $dataHelper)
@@ -35,6 +36,10 @@ class Mode
             [
                 'value' => self::PRODUCTION,
                 'label' => __('Production'),
+            ],
+            [
+                'value' => self::UAT,
+                'label' => __('UAT'),
             ],
         ];
 

--- a/Model/Adminhtml/Source/Mode.php
+++ b/Model/Adminhtml/Source/Mode.php
@@ -12,6 +12,7 @@ class Mode
     public const PRODUCTION = 'production';
     public const CUSTOM = 'custom';
     public const UAT = 'uat';
+
     protected $dataHelper;
 
     public function __construct(Data $dataHelper)

--- a/Model/PaymentMethod.php
+++ b/Model/PaymentMethod.php
@@ -174,7 +174,7 @@ class PaymentMethod extends AbstractMethod
         $this->orderRepository = $orderRepository;
         $this->infoFactory = $infoFactory;
         $this->searchCriteriaBuilder = $searchCriteriaBuilder;
-        $this->version = '2.0.1';
+        $this->version = '2.1.0';
 
         $this->placetoPayPayment = new PlacetoPayPayment(
             $config,

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 For more information about the component and the functionalities it offers, visit the following link **[Magento-Placetopay](https://placetopay.dev/plugins/magento)**.
 
 ## Prerequisites
-- `php` ^7.1
+- `php` ^7.4
 - `ext-bcmath`
 - `ext-ctype`
 - `ext-curl`
@@ -32,9 +32,11 @@ For more information about the component and the functionalities it offers, visi
     
 ## Compatibility Version
 
-| Magento | Plugin   | Comments       |
-|------------|----------|----------------|
-| 2.x.x      | ~1.8.0   | From 2.0.x  |
+| Magento | Plugin   | Comments        |
+|---------|----------|-----------------|
+| 2.4.4+  | ~2.1.0   | From 2.1.x      |
+
+> Note: Plugin 2.1.x requires Magento 2.4.4+ and PHP 7.4+. Earlier versions are not supported.
 
 View releases [here][link-releases]
 
@@ -173,8 +175,8 @@ if you wat to change the users and passwords, edit the env file.
 
 Default versions
 
-- Magento: 2.3.3
-- PHP: 7.2
+- Magento: 2.4.4 (minimum supported)
+- PHP: 7.4 (minimum supported)
 - MySQL: 5.6.23
 
 You can change versions in `.docker/Dockerfile`

--- a/composer.json
+++ b/composer.json
@@ -13,13 +13,15 @@
     }
   ],
   "require": {
-    "php": ">=7.2",
+    "php": ">=7.4",
     "ext-json": "*"
   },
   "require-dev": {
     "magento/magento-coding-standard": "*",
-    "magento/framework": ">=101.0.8 <102 || >=102.0.1",
-    "magento/module-vault": "101.*"
+    "magento/framework": "^103.0.4",
+    "magento/module-vault": "^101.2.0",
+    "dealerdirect/phpcodesniffer-composer-installer": "^1.2",
+    "phpcompatibility/php-compatibility": "^9.3"
   },
   "autoload": {
     "files": [
@@ -35,11 +37,13 @@
     ],
     "post-update-cmd": [
       "([ $COMPOSER_DEV_MODE -eq 0 ] || vendor/bin/phpcs --config-set installed_paths ../../magento/magento-coding-standard/)"
-    ]
+    ],
+    "phpcs:compat": "vendor/bin/phpcs -p --standard=PHPCompatibility --runtime-set testVersion 7.4-8.4 --ignore=vendor/* ."
   },
   "config": {
     "allow-plugins": {
-      "magento/composer-dependency-version-audit-plugin": true
+      "magento/composer-dependency-version-audit-plugin": true,
+      "dealerdirect/phpcodesniffer-composer-installer": true
     }
   }
 }

--- a/config/templates/AvalpayColombiaConfig.php
+++ b/config/templates/AvalpayColombiaConfig.php
@@ -17,6 +17,7 @@ abstract class CountryConfig
     {
         return [
             Mode::TEST => 'https://checkout.test.avalpaycenter.com',
+            Mode::UAT => 'https://checkout.uat.avalpaycenter.com',
             Mode::PRODUCTION => 'https://checkout.avalpaycenter.com',
         ];
     }

--- a/config/templates/BanchileChileConfig.php
+++ b/config/templates/BanchileChileConfig.php
@@ -16,6 +16,7 @@ abstract class CountryConfig
     {
         return [
             Mode::TEST => 'https://checkout.test.banchilepagos.cl',
+            Mode::UAT => 'https://checkout.uat.banchilepagos.cl',
             Mode::PRODUCTION => 'https://checkout.banchilepagos.cl',
         ];
     }

--- a/config/templates/GetnetChileConfig.php
+++ b/config/templates/GetnetChileConfig.php
@@ -16,6 +16,7 @@ abstract class CountryConfig
     {
         return [
             Mode::TEST => 'https://checkout.test.getnet.cl',
+            Mode::UAT => 'https://checkout.uat.getnet.cl',
             Mode::PRODUCTION => 'https://checkout.getnet.cl',
         ];
     }

--- a/config/templates/PlacetopayUruguayConfig.php
+++ b/config/templates/PlacetopayUruguayConfig.php
@@ -16,7 +16,7 @@ abstract class CountryConfig
     public static function getEndpoints(): array
     {
         return [
-            Mode::TEST => 'https://uy-uat-checkout.placetopay.com',
+            Mode::UAT => 'https://uy-uat-checkout.placetopay.com',
             Mode::PRODUCTION => 'https://checkout.placetopay.uy',
         ];
     }

--- a/etc/adminhtml/system/gateway.xml
+++ b/etc/adminhtml/system/gateway.xml
@@ -183,6 +183,52 @@
         </field>
 
         <field
+            id="placetopay_uat_lg"
+            translate="label comment"
+            type="text"
+            sortOrder="102"
+            showInDefault="1"
+            showInWebsite="1"
+            showInStore="1"
+        >
+            <label>UAT Login</label>
+
+            <comment>
+                <![CDATA[Your Placetopay Account > Sites > UAT Login]]>
+            </comment>
+
+            <depends>
+                <field id="placetopay_mode">uat</field>
+            </depends>
+
+            <config_path>payment/placetopay/placetopay_uat_lg</config_path>
+        </field>
+
+        <field
+            id="placetopay_uat_tk"
+            translate="label comment"
+            type="obscure"
+            sortOrder="104"
+            showInDefault="1"
+            showInWebsite="1"
+            showInStore="1"
+        >
+            <label>UAT TranKey</label>
+
+            <comment>
+                <![CDATA[Your Placetopay Account > Sites > UAT TranKey]]>
+            </comment>
+
+            <backend_model>Magento\Config\Model\Config\Backend\Encrypted</backend_model>
+
+            <depends>
+                <field id="placetopay_mode">uat</field>
+            </depends>
+
+            <config_path>payment/placetopay/placetopay_uat_tk</config_path>
+        </field>
+
+        <field
             id="placetopay_production_lg"
             translate="label comment"
             type="text"

--- a/etc/config.xml
+++ b/etc/config.xml
@@ -11,6 +11,7 @@
                 <!--<model>PlacetoPayPaymentsFacade</model>-->
                 <placetopay_development_tk backend_model="Magento\Config\Model\Config\Backend\Encrypted"/>
                 <placetopay_test_tk backend_model="Magento\Config\Model\Config\Backend\Encrypted"/>
+                <placetopay_uat_tk backend_model="Magento\Config\Model\Config\Backend\Encrypted"/>
                 <placetopay_production_tk backend_model="Magento\Config\Model\Config\Backend\Encrypted"/>
                 <placetopay_custom_tk backend_model="Magento\Config\Model\Config\Backend\Encrypted"/>
                 <title><![CDATA[Placetopay]]></title>

--- a/etc/config.xml
+++ b/etc/config.xml
@@ -18,7 +18,7 @@
                 <description><![CDATA[Pay securely through Placetopay.]]></description>
                 <allowspecific>0</allowspecific>
                 <sort_order>1</sort_order>
-                <expiration>2880</expiration>
+                <expiration>30</expiration>
                 <final_page>magento_default</final_page>
                 <allow_pending_payment>0</allow_pending_payment>
                 <allow_partial_payment>0</allow_partial_payment>


### PR DESCRIPTION
## [2.1.0] - 2026-02-26

### Added
- Add uat environments.
- Set expiration minutes in 30 minutes by default.

### Removed
- Remove support for Magento < 2.4.4.
- Remove support for PHP < 7.4.
